### PR TITLE
fix: handle sigterm

### DIFF
--- a/cmd/aqua-proxy/main.go
+++ b/cmd/aqua-proxy/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/suzuki-shunsuke/aqua-proxy/pkg/cli"
 	"github.com/suzuki-shunsuke/go-error-with-exit-code/ecerror"
@@ -21,7 +22,7 @@ func core() error {
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	return runner.Run(ctx, os.Args...) //nolint:wrapcheck
 }


### PR DESCRIPTION
Note that this fix doesn't work for Windows.

https://pkg.go.dev/os#Signal

> The only signal values guaranteed to be present in the os package on all systems are os.Interrupt (send the process an interrupt) and os.Kill (force the process to exit).
> On Windows, sending os.Interrupt to a process with os.Process.Signal is not implemented;
> it will return an error instead of sending a signal.